### PR TITLE
List clusters that have "master" in the name correctly

### DIFF
--- a/bin/gce-10acre-ranch
+++ b/bin/gce-10acre-ranch
@@ -368,7 +368,7 @@ build_cluster()
 main() 
 {
     if [[ "${LIST_NODES_FLAG}" = "true" && -z "${CLUSTER_NAME}" ]]; then
-        list_nodes | grep -- '-master-' | sed -e 's/^\(.*\)\(-10acre-master.*\)$/\1/' | sort -u
+        list_nodes | grep -- '-10acre-master-' | sed -e 's/^\(.*\)\(-10acre-master.*\)$/\1/' | sort -u
     elif [[ "${LIST_NODES_FLAG}" = "true" && "${CLUSTER_NAME}" ]]; then
         list_nodes 
     elif [ "${MASTER_IP_FLAG}" = "true" ]; then


### PR DESCRIPTION
`gce-10acre-ranch -l` currently lists a bunch of random host VMs that are not masters because the cluster was named "someone-master"